### PR TITLE
fix encoding in parseLoginLink

### DIFF
--- a/src/loginLinkUtils.ts
+++ b/src/loginLinkUtils.ts
@@ -40,6 +40,6 @@ export const createLoginLink = ({
 
 export const parseLoginLink = (link: string) => {
   return JSON.parse(
-    Buffer.from(decodeURIComponent(link), "base64").toString("ascii")
+    Buffer.from(decodeURIComponent(link), "base64").toString("utf8")
   );
 };


### PR DESCRIPTION
# Description

Fix an encoding issue in `parseLoginLink` method which caused strip of special characters
